### PR TITLE
Feature/max/july update

### DIFF
--- a/samples/ads/src/main/java/com/wscsports/blaze_sample_android/samples/ads/AdsSampleActivity.kt
+++ b/samples/ads/src/main/java/com/wscsports/blaze_sample_android/samples/ads/AdsSampleActivity.kt
@@ -7,6 +7,7 @@ import com.blaze.blazesdk.ads.models.ui.BlazeStoriesAdsConfigType
 import com.blaze.blazesdk.data_source.BlazeDataSourceType
 import com.blaze.blazesdk.data_source.BlazeWidgetLabel
 import com.blaze.blazesdk.delegates.BlazeWidgetDelegate
+import com.blaze.blazesdk.features.stories.models.configuration.BlazeStoriesPlaybackConfiguration
 import com.blaze.blazesdk.style.widgets.BlazeWidgetLayout
 import com.blaze.gam.nextgen.BlazeGAM
 import com.blaze.gam.nextgen.banner.BlazeGAMBannerAdsDelegate
@@ -87,7 +88,13 @@ class AdsSampleActivity : AppCompatActivity(),
             widgetLayout = BlazeWidgetLayout.Presets.StoriesWidget.Row.circles,
             dataSource = dataSource,
             widgetId = "ads-stories-row-id",
-            widgetDelegate = this
+            widgetDelegate = this,
+            // Opt-in pre-roll ads for the Stories player (disabled by default).
+            // When enabled, if the first unread page is a configured ad page, that ad is played
+            // there as a pre-roll before the story content. Leave as `.base()` to keep pre-rolls off.
+            playbackConfiguration = BlazeStoriesPlaybackConfiguration.base().apply {
+                ads.enablePreroll = true
+            }
         )
     }
 

--- a/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/MethodsDelegatesFragment.kt
+++ b/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/MethodsDelegatesFragment.kt
@@ -3,6 +3,7 @@ package com.wscsports.blaze_sample_android.samples.widgets.screens
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import android.view.View
 import androidx.fragment.app.Fragment
 import com.blaze.blazesdk.data_source.BlazeDataSourceType
@@ -65,6 +66,11 @@ class MethodsDelegatesFragment : Fragment(R.layout.fragment_methods_delegates),
      * - widgetId: The ID of the widget
      * - contentIndex: The zero-based index of the clicked item
      * - contentId: The unique content ID of the clicked item
+     * - extraInfo: Additional key-value metadata associated with the clicked item
+     * - contentThumbnailUrl: The URL of the clicked item's main thumbnail (matching the thumbnail
+     *   rendered by the widget), or null when the item has no thumbnail. Available for stories,
+     *   moments, and videos widgets. Useful when the app handles the click itself - e.g. showing a
+     *   paywall or preview screen with the item's thumbnail before playback.
      *
      * Return [BlazeWidgetItemClickHandlerState.SDK_SHOULD_HANDLE] to let the SDK handle the click,
      * or [BlazeWidgetItemClickHandlerState.HANDLED_BY_APP] to handle it yourself.
@@ -90,9 +96,17 @@ class MethodsDelegatesFragment : Fragment(R.layout.fragment_methods_delegates),
      *
      * This handler intercepts widget item clicks and manually triggers playback
      * using the content ID from the click params.
+     *
+     * It also demonstrates consuming [BlazeWidgetItemClickParams.contentThumbnailUrl]: the app can
+     * render the clicked item's thumbnail directly (e.g. on a paywall / preview screen) without
+     * maintaining its own contentId -> thumbnail mapping.
      */
     private fun handleWidgetItemClick(params: BlazeWidgetItemClickParams): BlazeWidgetItemClickHandlerState {
-        // Use a small delay to mock app doing some background work
+        // A real app would load `params.contentThumbnailUrl` into an ImageView on its paywall /
+        // preview screen. Here we just log it and mock some background work before playback.
+        Log.d("MethodsDelegates", "Presenting paywall with thumbnail: ${params.contentThumbnailUrl ?: "none"}")
+
+        // Use a small delay to mock app doing some background work (e.g. subscription check).
         Handler(Looper.getMainLooper()).postDelayed({
             // Play from the clicked item's content ID
             binding.storiesWidgetView.play(

--- a/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/MomentsGridFragment.kt
+++ b/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/MomentsGridFragment.kt
@@ -9,6 +9,7 @@ import com.blaze.blazesdk.style.shared.models.BlazeObjectXPosition
 import com.blaze.blazesdk.style.shared.models.BlazeObjectYPosition
 import com.blaze.blazesdk.style.shared.models.blazeDp
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemBadgeStyle
+import com.blaze.blazesdk.shared.models.BlazeExtraInfoKeyPreset
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemCustomMapping
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageStyle
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageStyle.BlazeImagePosition
@@ -244,7 +245,7 @@ class MomentsGridFragment : BaseWidgetFragment(R.layout.fragment_moments_grid) {
     // For more information see https://dev.wsc-sports.com/docs/android-blaze-widget-item-custom-mapping#/
     private fun setOverrideStylesByPlayerId(widgetLayout: BlazeWidgetLayout) {
         val layoutDeepCopy = widgetLayout.blazeDeepCopy()
-        val mappingKey =  BlazeWidgetItemCustomMapping.BlazeKeysPresets.PLAYER_ID
+        val mappingKey =  BlazeExtraInfoKeyPreset.PLAYER_ID
         val mappingValue = "441303"
         binding.momentsGridWidgetView.updateOverrideStyles(
             perItemStyleOverrides = mapOf(

--- a/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/MomentsRowFragment.kt
+++ b/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/MomentsRowFragment.kt
@@ -9,6 +9,7 @@ import com.blaze.blazesdk.style.shared.models.BlazeObjectXPosition
 import com.blaze.blazesdk.style.shared.models.BlazeObjectYPosition
 import com.blaze.blazesdk.style.shared.models.blazeDp
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemBadgeStyle
+import com.blaze.blazesdk.shared.models.BlazeExtraInfoKeyPreset
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemCustomMapping
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageGradientOverlayStyle
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageGradientOverlayStyle.BlazeGradientPosition
@@ -253,7 +254,7 @@ class MomentsRowFragment : BaseWidgetFragment(R.layout.fragment_moments_row) {
     // For more information see https://dev.wsc-sports.com/docs/android-blaze-widget-item-custom-mapping#/
     private fun setOverrideStylesByTeamId(widgetLayout: BlazeWidgetLayout) {
         val layoutDeepCopy = widgetLayout.blazeDeepCopy()
-        val mappingKey =  BlazeWidgetItemCustomMapping.BlazeKeysPresets.TEAM_ID
+        val mappingKey =  BlazeExtraInfoKeyPreset.TEAM_ID
         val mappingValue = "185"
         binding.momentsRowWidgetView.updateOverrideStyles(
             perItemStyleOverrides = mapOf(

--- a/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/StoriesGridFragment.kt
+++ b/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/StoriesGridFragment.kt
@@ -9,6 +9,7 @@ import com.blaze.blazesdk.style.shared.models.BlazeObjectXPosition
 import com.blaze.blazesdk.style.shared.models.BlazeObjectYPosition
 import com.blaze.blazesdk.style.shared.models.blazeDp
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemBadgeStyle
+import com.blaze.blazesdk.shared.models.BlazeExtraInfoKeyPreset
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemCustomMapping
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageStyle
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageStyle.BlazeImagePosition
@@ -256,7 +257,7 @@ class StoriesGridFragment : BaseWidgetFragment(R.layout.fragment_stories_grid) {
     // For more information see https://dev.wsc-sports.com/docs/android-blaze-widget-item-custom-mapping#/
     private fun setOverrideStylesByGameId(widgetLayout: BlazeWidgetLayout) {
         val layoutDeepCopy = widgetLayout.blazeDeepCopy() // we create a deep copy of the layout to avoid modifying the original layout
-        val mappingKey =  BlazeWidgetItemCustomMapping.BlazeKeysPresets.PLAYER_ID
+        val mappingKey =  BlazeExtraInfoKeyPreset.PLAYER_ID
         val mappingValue = "593109"
         binding.storiesGridWidgetView.updateOverrideStyles(
             perItemStyleOverrides = mapOf(

--- a/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/StoriesRowFragment.kt
+++ b/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/StoriesRowFragment.kt
@@ -9,6 +9,7 @@ import com.blaze.blazesdk.style.shared.models.BlazeObjectXPosition
 import com.blaze.blazesdk.style.shared.models.BlazeObjectYPosition
 import com.blaze.blazesdk.style.shared.models.blazeDp
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemBadgeStyle
+import com.blaze.blazesdk.shared.models.BlazeExtraInfoKeyPreset
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemCustomMapping
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageGradientOverlayStyle.BlazeGradientPosition
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageStyle
@@ -276,7 +277,7 @@ class StoriesRowFragment: BaseWidgetFragment(R.layout.fragment_stories_row) {
     // For more information see https://dev.wsc-sports.com/docs/android-blaze-widget-item-custom-mapping#/
     private fun setOverrideStylesByGameId(widgetLayout: BlazeWidgetLayout) {
         val layoutDeepCopy = widgetLayout.blazeDeepCopy() // we create a deep copy of the layout to avoid modifying the original layout
-        val mappingKey =  BlazeWidgetItemCustomMapping.BlazeKeysPresets.PLAYER_ID
+        val mappingKey =  BlazeExtraInfoKeyPreset.PLAYER_ID
         val mappingValue = "593109"
         binding.storiesRowWidgetView.updateOverrideStyles(
             perItemStyleOverrides = mapOf(

--- a/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/VideosGridFragment.kt
+++ b/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/VideosGridFragment.kt
@@ -9,6 +9,7 @@ import com.blaze.blazesdk.style.shared.models.BlazeObjectXPosition
 import com.blaze.blazesdk.style.shared.models.BlazeObjectYPosition
 import com.blaze.blazesdk.style.shared.models.blazeDp
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemBadgeStyle
+import com.blaze.blazesdk.shared.models.BlazeExtraInfoKeyPreset
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemCustomMapping
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageGradientOverlayStyle.BlazeGradientPosition
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageStyle
@@ -210,7 +211,7 @@ class VideosGridFragment : BaseWidgetFragment(R.layout.fragment_videos_grid) {
     // For more information see https://dev.wsc-sports.com/docs/android-blaze-widget-item-custom-mapping#/
     private fun setOverrideStylesByTeamId(widgetLayout: BlazeWidgetLayout) {
         val layoutDeepCopy = widgetLayout.blazeDeepCopy()
-        val mappingKey =  BlazeWidgetItemCustomMapping.BlazeKeysPresets.GAME_ID
+        val mappingKey =  BlazeExtraInfoKeyPreset.GAME_ID
         val mappingValue = "2445381"
         binding.videosGridWidgetView.updateOverrideStyles(
             perItemStyleOverrides = mapOf(

--- a/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/VideosRowFragment.kt
+++ b/samples/widgets/src/main/java/com/wscsports/blaze_sample_android/samples/widgets/screens/VideosRowFragment.kt
@@ -10,6 +10,7 @@ import com.blaze.blazesdk.style.shared.models.BlazeObjectXPosition
 import com.blaze.blazesdk.style.shared.models.BlazeObjectYPosition
 import com.blaze.blazesdk.style.shared.models.blazeDp
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemBadgeStyle
+import com.blaze.blazesdk.shared.models.BlazeExtraInfoKeyPreset
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemCustomMapping
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageGradientOverlayStyle.BlazeGradientPosition
 import com.blaze.blazesdk.style.widgets.BlazeWidgetItemImageStyle
@@ -217,7 +218,7 @@ class VideosRowFragment : BaseWidgetFragment(R.layout.fragment_videos_row) {
     // For more information see https://dev.wsc-sports.com/docs/android-blaze-widget-item-custom-mapping#/
     private fun setOverrideStylesByTeamId(widgetLayout: BlazeWidgetLayout) {
         val layoutDeepCopy = widgetLayout.blazeDeepCopy()
-        val mappingKey =  BlazeWidgetItemCustomMapping.BlazeKeysPresets.GAME_ID
+        val mappingKey =  BlazeExtraInfoKeyPreset.GAME_ID
         val mappingValue = "2445381"
         binding.videosRowWidgetView.updateOverrideStyles(
             perItemStyleOverrides = mapOf(


### PR DESCRIPTION
Sample code for the July SDK update: widget thumbnail URL, opt-in Stories pre-roll (in the ads sample), and BlazeKeysPresets→BlazeExtraInfoKeyPreset cleanup